### PR TITLE
Dynamic Swipe add/delete

### DIFF
--- a/SwipeMeal.xcodeproj/project.pbxproj
+++ b/SwipeMeal.xcodeproj/project.pbxproj
@@ -23,6 +23,7 @@
 		165304B51D569640006A0760 /* Montserrat-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = 165304AD1D569640006A0760 /* Montserrat-Regular.otf */; };
 		165304B61D569640006A0760 /* Montserrat-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = 165304AE1D569640006A0760 /* Montserrat-SemiBold.otf */; };
 		165304B71D569640006A0760 /* Montserrat-UltraLight.otf in Resources */ = {isa = PBXBuildFile; fileRef = 165304AF1D569640006A0760 /* Montserrat-UltraLight.otf */; };
+		165304BD1D5698CA006A0760 /* SwipeStore.m in Sources */ = {isa = PBXBuildFile; fileRef = 165304BC1D5698CA006A0760 /* SwipeStore.m */; };
 		168656B41D1EB99F004CE47D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 168656B21D1EB99F004CE47D /* Main.storyboard */; };
 		168656BA1D1EC830004CE47D /* HomeViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 168656B91D1EC830004CE47D /* HomeViewController.m */; };
 		168656BE1D1EC9F5004CE47D /* HomeHeaderTableViewCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 168656BD1D1EC9F5004CE47D /* HomeHeaderTableViewCell.m */; };
@@ -103,6 +104,8 @@
 		165304AD1D569640006A0760 /* Montserrat-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Montserrat-Regular.otf"; sourceTree = "<group>"; };
 		165304AE1D569640006A0760 /* Montserrat-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Montserrat-SemiBold.otf"; sourceTree = "<group>"; };
 		165304AF1D569640006A0760 /* Montserrat-UltraLight.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Montserrat-UltraLight.otf"; sourceTree = "<group>"; };
+		165304BB1D5698CA006A0760 /* SwipeStore.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = SwipeStore.h; path = SwipeMeal/Models/SwipeStore.h; sourceTree = "<group>"; };
+		165304BC1D5698CA006A0760 /* SwipeStore.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = SwipeStore.m; path = SwipeMeal/Models/SwipeStore.m; sourceTree = "<group>"; };
 		168656B31D1EB99F004CE47D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = SwipeMeal/Base.lproj/Main.storyboard; sourceTree = "<group>"; };
 		168656B71D1EC82F004CE47D /* SwipeMeal-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "SwipeMeal-Bridging-Header.h"; sourceTree = "<group>"; };
 		168656B81D1EC830004CE47D /* HomeViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = HomeViewController.h; path = SwipeMeal/ViewControllers/HomeViewController.h; sourceTree = "<group>"; };
@@ -300,6 +303,8 @@
 				168656CD1D1F2D53004CE47D /* Message.m */,
 				16ABC4C31D4C40B700A2AAA4 /* Swipe.h */,
 				16ABC4C41D4C40B800A2AAA4 /* Swipe.m */,
+				165304BB1D5698CA006A0760 /* SwipeStore.h */,
+				165304BC1D5698CA006A0760 /* SwipeStore.m */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -644,6 +649,7 @@
 				CE67668A1D09D450003D6EF0 /* UIStoryboard+Extensions.swift in Sources */,
 				CE34EA551D189233003408EB /* AddProfileImageViewController.swift in Sources */,
 				168656D41D204636004CE47D /* MessagesDetailViewController.m in Sources */,
+				165304BD1D5698CA006A0760 /* SwipeStore.m in Sources */,
 				16ABC4C21D4C3FDE00A2AAA4 /* SwipeBuyTableViewCell.m in Sources */,
 				CE1D776B1CF76FB30071D249 /* SignUpInfo.swift in Sources */,
 				CE7748951D134175007F24C2 /* AuthenticateLoginOperation.swift in Sources */,

--- a/SwipeMeal/Models/Swipe.h
+++ b/SwipeMeal/Models/Swipe.h
@@ -11,6 +11,7 @@
 
 @interface Swipe : NSObject
 
+@property (strong, nonatomic) NSString *swipeID;
 @property (nonatomic) NSInteger price;
 @property (strong, nonatomic) UIImage *sellerImage;
 @property (strong, nonatomic) NSString *sellerName;

--- a/SwipeMeal/Models/SwipeStore.h
+++ b/SwipeMeal/Models/SwipeStore.h
@@ -1,0 +1,21 @@
+//
+//  SwipeStore.h
+//  SwipeMeal
+//
+//  Created by Jacob Harris on 8/6/16.
+//  Copyright © 2016 Incipia. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+#import "Swipe.h"
+
+@interface SwipeStore : NSObject
+
++ (SwipeStore *)sharedSwipeStore;
+- (BOOL)containsSwipeKey:(NSString *)key;
+- (void)addSwipe:(Swipe *)swipe forKey:(NSString *)key;
+- (void)removeSwipe:(Swipe *)swipe forKey:(NSString *)key;
+- (Swipe *)swipeForKey:(NSString *)key;
+- (NSArray *)swipesSortedByPriceAscending;
+
+@end

--- a/SwipeMeal/Models/SwipeStore.m
+++ b/SwipeMeal/Models/SwipeStore.m
@@ -1,0 +1,73 @@
+//
+//  SwipeStore.m
+//  SwipeMeal
+//
+//  Created by Jacob Harris on 8/6/16.
+//  Copyright © 2016 Incipia. All rights reserved.
+//
+
+#import "SwipeStore.h"
+
+@implementation SwipeStore {
+    NSMutableDictionary *_swipesBySwipeID;
+}
+
++ (SwipeStore *)sharedSwipeStore {
+    static SwipeStore *swipeStore = nil;
+    if (!swipeStore) {
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            swipeStore = [[SwipeStore alloc] init];
+        });
+    }
+    
+    return swipeStore;
+}
+
+- (instancetype)init {
+    if (self = [super init]) {
+        _swipesBySwipeID = [NSMutableDictionary dictionary];
+    }
+    
+    return self;
+}
+
+- (BOOL)containsSwipeKey:(NSString *)key {
+    if ([_swipesBySwipeID objectForKey:key]) {
+        return YES;
+    }
+    
+    return NO;
+}
+
+- (void)addSwipe:(Swipe *)swipe forKey:(NSString *)key {
+    [_swipesBySwipeID setObject:swipe forKey:key];
+}
+
+- (void)removeSwipe:(Swipe *)swipe forKey:(NSString *)key {
+    [_swipesBySwipeID removeObjectForKey:key];
+}
+
+- (Swipe *)swipeForKey:(NSString *)key {
+    Swipe *swipe = [_swipesBySwipeID objectForKey:key];
+    return swipe;
+}
+
+- (NSArray *)swipesSortedByPriceAscending {
+    NSArray *swipeKeys = [_swipesBySwipeID keysSortedByValueUsingComparator:^NSComparisonResult(id  _Nonnull obj1, id  _Nonnull obj2) {
+        Swipe *swipe1 = (Swipe *)obj1;
+        Swipe *swipe2 = (Swipe *)obj2;
+        
+        return [@(swipe1.price) compare:@(swipe2.price)];
+    }];
+
+    NSMutableArray *swipes = [NSMutableArray array];
+    for (NSString *key in swipeKeys) {
+        Swipe *swipe = [_swipesBySwipeID objectForKey:key];
+        [swipes addObject:swipe];
+    }
+    
+    return swipes;
+}
+
+@end

--- a/SwipeMeal/ViewControllers/SwipeBuyViewController.m
+++ b/SwipeMeal/ViewControllers/SwipeBuyViewController.m
@@ -10,12 +10,13 @@
 #import "Swipe.h"
 #import "SwipeBuyTableViewCell.h"
 #import "SwipeBuyDetailViewController.h"
+#import "SwipeStore.h"
 @import Firebase;
 
 @interface SwipeBuyViewController () <UITableViewDelegate, UITableViewDataSource>
 
 @property (weak, nonatomic) IBOutlet UITableView *tableView;
-@property (strong, nonatomic) NSMutableArray *swipes;
+@property (strong, nonatomic) SwipeStore *swipeStore;
 @property (strong, nonatomic) Swipe *selectedSwipe;
 @property (strong, nonatomic) FIRDatabaseReference *dbRef;
 
@@ -26,46 +27,43 @@
 - (void)viewDidLoad {
     [super viewDidLoad];
     
-    self.dbRef = [[FIRDatabase database] reference];
-    self.swipes = [NSMutableArray array];
+    self.dbRef = [[FIRDatabase database] referenceWithPath:@"/swipes/"];
+    self.swipeStore = [SwipeStore sharedSwipeStore];
     self.tableView.delegate = self;
     self.tableView.dataSource = self;
     
-    [self getInitialData];
+    [self listenForEvents];
 }
 
-- (void)getInitialData {
-    [[self.dbRef child:@"swipes"] observeSingleEventOfType:FIRDataEventTypeValue withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {
-        NSLog(@"%@", snapshot.value);
-        
-        for (NSString *key in snapshot.value ) {
-            NSDictionary *swipeDict = [snapshot.value objectForKey:key];
-            Swipe *swipe = [self swipeWithAttrs:swipeDict];
-            [self.swipes addObject:swipe];
-            
-            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:[self.swipes count] - 1 inSection:0];
-            [self.tableView insertRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+- (void)listenForEvents {
+    [self.dbRef observeEventType:FIRDataEventTypeChildAdded withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {
+        Swipe *swipe = [self swipeWithSnapshot:snapshot];
+        if ([_swipeStore containsSwipeKey:swipe.swipeID]) {
+            NSIndexPath *indexPath = [NSIndexPath indexPathForRow:[[self.swipeStore swipesSortedByPriceAscending] count] - 1 inSection:0];
+            [self.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
+        } else {
+            [self.swipeStore addSwipe:swipe forKey:swipe.swipeID];
+            NSLog(@"ADDED: %@", swipe);
+            [self.tableView reloadData];
         }
+    }];
+    
+    [self.dbRef observeEventType:FIRDataEventTypeChildRemoved withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {
+        Swipe *swipe = [self swipeWithSnapshot:snapshot];
+        [self.swipeStore removeSwipe:swipe forKey:swipe.swipeID];
+        NSLog(@"REMOVED: %@", snapshot);
+        [self.tableView reloadData];
     }];
 }
 
-//- (void)listenForEvents {
-//    [self.dbRef observeEventType:FIRDataEventTypeChildAdded withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {
-//        NSLog(@"ADDED: %@", snapshot);
-//    }];
-//    
-//    [self.dbRef observeEventType:FIRDataEventTypeChildRemoved withBlock:^(FIRDataSnapshot * _Nonnull snapshot) {
-//        NSLog(@"REMOVED: %@", snapshot);
-//    }];
-//}
-
-- (Swipe *)swipeWithAttrs:(NSDictionary *)attrs {
+- (Swipe *)swipeWithSnapshot:(FIRDataSnapshot *)snapshot {
     Swipe *swipe = [[Swipe alloc] init];
-    swipe.sellerName = [attrs objectForKey:@"seller_name"];
-    swipe.sellerRating = [[attrs objectForKey:@"seller_rating"] integerValue];
-    swipe.price = [[attrs objectForKey:@"price"] integerValue];
-    swipe.locationName = [attrs objectForKey:@"location_name"];
-    swipe.listingTime = [[attrs objectForKey:@"listing_time"] floatValue];
+    swipe.swipeID = snapshot.key;
+    swipe.sellerName = [snapshot.value objectForKey:@"seller_name"];
+    swipe.sellerRating = [[snapshot.value objectForKey:@"seller_rating"] integerValue];
+    swipe.price = [[snapshot.value objectForKey:@"price"] integerValue];
+    swipe.locationName = [snapshot.value objectForKey:@"location_name"];
+    swipe.listingTime = [[snapshot.value objectForKey:@"listing_time"] floatValue];
     
     return swipe;
 }
@@ -80,7 +78,7 @@
 #pragma mark - UITableViewDataSource
 
 - (NSInteger)tableView:(UITableView *)tableView numberOfRowsInSection:(NSInteger)section {
-    NSInteger count = [self.swipes count];
+    NSInteger count = [[self.swipeStore swipesSortedByPriceAscending] count];
     return count;
 }
 
@@ -88,14 +86,14 @@
 
 - (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath {
     SwipeBuyTableViewCell *cell = (SwipeBuyTableViewCell *)[tableView dequeueReusableCellWithIdentifier:@"SwipeBuyTableViewCell"];
-    Swipe *swipe = [self.swipes objectAtIndex:indexPath.row];
+    Swipe *swipe = [[self.swipeStore swipesSortedByPriceAscending] objectAtIndex:indexPath.row];
     cell.swipe = swipe;
     
     return cell;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath {
-    self.selectedSwipe = [self.swipes objectAtIndex:indexPath.row];
+    self.selectedSwipe = [[self.swipeStore swipesSortedByPriceAscending] objectAtIndex:indexPath.row];
     [self performSegueWithIdentifier:@"Segue_SwipeBuyViewController_SwipeBuyDetailViewController" sender:nil];
 }
 


### PR DESCRIPTION
Now supports dynamic inserting and deleting of Swipes. Also added a SwipeStore for keeping track of Swipes throughout the app.

**To test dynamic add:**
Run the app on two devices. List a Swipe for sale on one device and the you should see it insert on the other.

**To test dynamic delete:**
Run the app on a device. In Firebase, go to the `/swipes` child and delete one of the objects. You should see it disappear from the table in the app.
